### PR TITLE
Change telnet library, add feedback support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
-var tcp = require('../../tcp');
-var instance_skel = require('../../instance_skel');
-var TelnetSocket = require("telnet-stream").TelnetSocket;
+var instance_skel = require("../../instance_skel");
+var telnet = require("telnet-client");
+
 var debug;
 var log;
 
+var reconnectTimer;
+var pollTimer;
+
+const STATUS_UNKNOWN = null;
+const STATUS_OK = 0;
+const STATUS_WARNING = 1;
+const STATUS_ERROR = 2;
 
 function instance(system, id, config) {
 	var self = this;
@@ -13,8 +20,10 @@ function instance(system, id, config) {
 	self.login = false;
 	// super-constructor
 	instance_skel.apply(this, arguments);
-	self.status(1,'Initializing');
+	self.status(1, "Initializing");
 	self.actions(); // export actions
+
+	self.activeCuelists = [];
 
 	return self;
 }
@@ -25,7 +34,6 @@ instance.prototype.updateConfig = function(config) {
 	self.init_tcp();
 };
 
-
 instance.prototype.init = function() {
 	var self = this;
 
@@ -33,249 +41,319 @@ instance.prototype.init = function() {
 	log = self.log;
 
 	self.init_tcp();
+	self.init_feedbacks();
 };
 
 instance.prototype.init_tcp = function() {
 	var self = this;
-	var receivebuffer = '';
 
-	if (self.socket !== undefined) {
-		self.socket.destroy();
-		delete self.socket;
+	if (self.tnc !== undefined) {
+		self.tnc.destroy();
+		delete self.tnc;
 		self.login = false;
 	}
 
 	if (self.config.host) {
-		self.socket = new tcp(self.config.host, self.config.port);
+		self.tnc = new telnet();
 
-		self.socket.on('status_change', function (status, message) {
-			self.status(status, message);
+		self.tnc.connect({
+			host: self.config.host,
+			port: self.config.port,
+			shellPrompt: "",
+			timeout: 1500,
+			negotiationMandatory: false
 		});
 
-		self.socket.on('error', function (err) {
-			debug("Network error", err);
-			self.log('error',"Network error: " + err.message);
+		if (reconnectTimer) {
+			clearInterval(reconnectTimer);
+		}
+
+		self.tnc.on("ready", function(data) {
+			self.status(STATUS_OK, "Connected");
+			self.login = true;
+
+			if (self.config.polling_interval > 0) {
+				pollTimer = setInterval(
+					pollActiveCuelists,
+					self.config.polling_interval
+				);
+			}
 		});
 
-		self.socket.on('connect', function () {
-			debug("Connected");
-			self.login = false;
+		self.tnc.on("close", function() {
+			self.status(STATUS_ERROR, "Disconnected");
+			if (!reconnectTimer) {
+				reconnectTimer = setInterval(function() {
+					self.init_tcp(), 5000;
+				});
+			}
 		});
-
-		self.telnet = new TelnetSocket(self.socket.socket);
-
-		self.socket.on('error', function (err) {
-			debug("Network error", err);
-			self.log('error',"Network error: " + err.message);
-		});
-
-		// if we get any data, display it to stdout
-		self.telnet.on("data", function(buffer) {
-			var indata = buffer.toString("utf8");
-			// self.incomingData(indata);
-		});
-
-		// tell remote we WONT do anything we're asked to DO
-		self.telnet.on("do", function(option) {
-			return self.telnet.writeWont(option);
-		});
-
-		// tell the remote DONT do whatever they WILL offer
-		self.telnet.on("will", function(option) {
-			return self.telnet.writeDont(option);
-		});
-
 	}
+
+	pollActiveCuelists = function() {
+		self.gettingActiveQL = true;
+		self.activeCuelists = [];
+		self.tnc.send("QLActive", { waitfor: ".\r\n" }).then(function(data) {
+			var lines = data.split("\r\n");
+			lines.forEach(function each(line) {
+				switch (line) {
+					// Ignore lines that aren't part of the active cuelist list.
+					case "200 Ok":
+					case "200 ":
+					case ".":
+					case "":
+					case "No Active Qlist in List":
+						break;
+					default:
+						var id = parseInt(line.substring(0, 5));
+						self.activeCuelists.push(id);
+						break;
+				}
+			});
+			self.checkFeedbacks("cuelist_active");
+		});
+	};
 };
 
 // Return config fields for web config
-instance.prototype.config_fields = function () {
+instance.prototype.config_fields = function() {
 	var self = this;
 
 	return [
 		{
-			type: 'text',
-			id: 'info',
+			type: "text",
+			id: "info",
 			width: 12,
-			label: 'Information',
-			value: 'Control ONYX (formerly Martin M-Series) consoles with Companion! Enable telnet in ONYX Manager'
+			label: "Information",
+			value:
+				"Control ONYX (formerly Martin M-Series) consoles with Companion! Enable telnet in ONYX Manager"
 		},
 		{
-			type: 'textinput',
-			id: 'host',
-			label: 'ONYX Console IP',
+			type: "textinput",
+			id: "host",
+			label: "ONYX Console IP",
 			width: 6,
-			default: '192.168.0.1',
+			default: "192.168.0.1",
 			regex: self.REGEX_IP
 		},
 		{
-			type: 'textinput',
-			id: 'port',
-			label: 'Port',
+			type: "textinput",
+			id: "port",
+			label: "Port",
 			width: 6,
-			default: '2323',
+			default: "2323"
+		},
+		{
+			type: "textinput",
+			id: "polling_interval",
+			label: "Polling Interval (ms)",
+			width: 4,
+			default: "5000"
 		}
-	]
+	];
 };
 
 // When module gets deleted
 instance.prototype.destroy = function() {
 	var self = this;
 
-	if (self.socket !== undefined) {
-		self.socket.destroy();
+	clearInterval(pollTimer);
+	clearInterval(reconnectTimer);
+	if (self.tnc !== undefined) {
+		self.tnc.destroy();
+		delete self.tnc;
 	}
 
-	debug("destroy", self.id);;
+	debug("destroy", self.id);
 };
 
 instance.prototype.actions = function(system) {
 	var self = this;
-	self.system.emit('instance_actions', self.id, {
+	self.system.emit("instance_actions", self.id, {
+		clearclear: { label: "Clear Programmer" },
+		release_all_overrides: { label: "Release All Overrides" },
+		release_all_cl: { label: "Release All Cuelists" },
+		release_all_cl_df: { label: "Release All Cuelist Dimmer First" },
+		release_all_cl_or_df: {
+			label: "Release All Cuelist and Override Dimmer First"
+		},
+		release_all_cl_or: { label: "Release All Cuelist and Override" },
 
-		'clearclear':               {label:'Clear Programmer'},
-		'release_all_overrides':    {label:'Release All Overrides'},
-		'release_all_cl':           {label:'Release All Cuelists'},
-		'release_all_cl_df':        {label:'Release All Cuelist Dimmer First'},
-		'release_all_cl_or_df':     {label:'Release All Cuelist and Override Dimmer First'},
-		'release_all_cl_or':        {label:'Release All Cuelist and Override'},
-
-		'command': {
-			label:'Run Other Command',
+		command: {
+			label: "Run Other Command",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Command',
-					 id: 'command',
-					 default: '',
+					type: "textinput",
+					label: "Command",
+					id: "command",
+					default: ""
 				}
 			]
 		},
-		'go_list_cue': {
-			label:'Go Cuelist',
+		go_list_cue: {
+			label: "Go Cuelist",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Cuelist Number',
-					 id: 'cuelist',
-					 default: '',
+					type: "textinput",
+					label: "Cuelist Number",
+					id: "cuelist",
+					default: ""
 				}
 			]
 		},
-		'go_schedule': {
-			label:'Go Schedule',
+		go_schedule: {
+			label: "Go Schedule",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Schedule Number',
-					 id: 'schedule',
-					 default: '',
+					type: "textinput",
+					label: "Schedule Number",
+					id: "schedule",
+					default: ""
 				}
 			]
 		},
-		'pause_cuelist': {
-			label:'Pause Cuelist',
+		pause_cuelist: {
+			label: "Pause Cuelist",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Cuelist Number',
-					 id: 'cuelist',
-					 default: '',
+					type: "textinput",
+					label: "Cuelist Number",
+					id: "cuelist",
+					default: ""
 				}
 			]
 		},
-		'release_cl': {
-			label:'Release Cuelist',
+		release_cl: {
+			label: "Release Cuelist",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Cuelist Number',
-					 id: 'cuelist',
-					 default: '',
+					type: "textinput",
+					label: "Cuelist Number",
+					id: "cuelist",
+					default: ""
 				}
 			]
 		},
-		'go_cue': {
-			label:'Go Cue in Cuelist',
+		go_cue: {
+			label: "Go Cue in Cuelist",
 			options: [
 				{
-					 type: 'textinput',
-					 label: 'Cuelist Number',
-					 id: 'cuelist',
-					 default: '',
+					type: "textinput",
+					label: "Cuelist Number",
+					id: "cuelist",
+					default: ""
 				},
 				{
-					 type: 'textinput',
-					 label: 'Cue Number',
-					 id: 'cue',
-					 default: '',
+					type: "textinput",
+					label: "Cue Number",
+					id: "cue",
+					default: ""
 				}
 			]
 		}
 	});
-}
+};
 
 instance.prototype.action = function(action) {
 	var self = this;
-	var cmd
-	var opt = action.options
+	var cmd;
+	var opt = action.options;
 
 	switch (action.action) {
-
-		case 'command':
+		case "command":
 			cmd = action.options.command;
 			break;
 
-		case 'clearclear':
-			cmd = 'CLRCLR';
+		case "clearclear":
+			cmd = "CLRCLR";
 			break;
 
-		case 'go_list_cue':
-			cmd = 'GQL ' + opt.cuelist;
+		case "go_list_cue":
+			cmd = "GQL " + opt.cuelist;
 			break;
 
-		case 'go_schedule':
-			cmd = 'GSC ' + opt.schedule;
+		case "go_schedule":
+			cmd = "GSC " + opt.schedule;
 			break;
 
-		case 'go_cue':
-			cmd = 'GTQ ' + opt.cuelist + ',' + opt.cue;
+		case "go_cue":
+			cmd = "GTQ " + opt.cuelist + "," + opt.cue;
 			break;
 
-		case 'release_all_overrides':
-			cmd = 'RAO';
+		case "release_all_overrides":
+			cmd = "RAO";
 			break;
 
-		case 'release_all_cl':
-			cmd = 'RAQL'
+		case "release_all_cl":
+			cmd = "RAQL";
 			break;
 
-		case 'release_all_cl_df':
-			cmd = 'RAQLDF';
+		case "release_all_cl_df":
+			cmd = "RAQLDF";
 			break;
 
-		case 'release_all_cl_or_df':
-			cmd = 'RAQLODF';
+		case "release_all_cl_or_df":
+			cmd = "RAQLODF";
 			break;
 
-		case 'release_all_cl_or':
-			cmd = 'RAQLO';
+		case "release_all_cl_or":
+			cmd = "RAQLO";
 			break;
 
-		case 'release_cl':
-			cmd = 'RQL ' + opt.cuelist;
+		case "release_cl":
+			cmd = "RQL " + opt.cuelist;
 			break;
-
-	};
+	}
 
 	if (cmd !== undefined) {
-
-		if (self.socket !== undefined && self.socket.connected) {
-			self.telnet.write(cmd+"\r\n");
+		if (self.tnc !== undefined) {
+			self.tnc.send(cmd + "\r\n");
 		} else {
-			debug('Socket not connected :(');
+			debug("Socket not connected :(");
 		}
+	}
+};
 
+instance.prototype.init_feedbacks = function() {
+	var self = this;
+
+	var feedbacks = {};
+	feedbacks["cuelist_active"] = {
+		label: "Active Cuelist",
+		description:
+			"If the specified cuelist is active, change colors of the bank",
+		options: [
+			{
+				type: "colorpicker",
+				label: "Foreground color",
+				id: "fg",
+				default: self.rgb(255, 255, 255)
+			},
+			{
+				type: "colorpicker",
+				label: "Background color",
+				id: "bg",
+				default: self.rgb(0, 255, 0)
+			},
+			{
+				type: "textinput",
+				label: "Cuelist Number",
+				id: "index",
+				default: 0,
+				regex: self.REGEX_NUMBER
+			}
+		]
+	};
+
+	self.setFeedbackDefinitions(feedbacks);
+};
+
+instance.prototype.feedback = function(feedback, bank) {
+	var self = this;
+	if (feedback.type == "cuelist_active") {
+		if (self.activeCuelists.indexOf(parseInt(feedback.options.index)) > -1) {
+			return { color: feedback.options.fg, bgcolor: feedback.options.bg };
+		}
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,18 @@
 	},
 	"license": "MIT",
 	"api_version": "1.0.0",
-	"keywords": [ "Lighting" ],
-	"manufacturer": ["elation", "martin"],
+	"keywords": [
+		"Lighting"
+	],
+	"manufacturer": [
+		"elation",
+		"martin"
+	],
 	"product": "ONYX",
 	"shortname": "onyx",
 	"homepage": "https://www.obsidiancontrol.com",
 	"author": "Oliver Herrmann <oliver@monoxane.com>",
 	"dependencies": {
-		"telnet-stream": "^1.0.4"
+		"telnet-client": "^0.15.0"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
-telnet-stream@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/telnet-stream/-/telnet-stream-1.0.4.tgz#50ac8f10e7899adc3128e9a404c5b3fcb3883a9e"
+bluebird@3.5.x:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
+telnet-client@^0.15.0:
+  version "0.15.8"
+  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-0.15.8.tgz#f2cf863227242a1a13a960f07089bde5c6980a38"
+  integrity sha512-vXAmmC7LwJoNwzQrku6KrHo2yirkCyqunYwcfYPSNHZUwO/JUBZVY5lH0rv3A4lRQzL7eGt8t8BFYJXwpGXm5Q==
+  dependencies:
+    bluebird "3.5.x"


### PR DESCRIPTION
Switches `telnet-stream` library to `telnet-client` as there was a licensing issue per Oliver Herrmann on Slack.

Also adds feedback support for active cuelists. This module has to poll the Onyx telnet interface to get a list of currently active cuelists, and the Onyx telnet interface is not the fastest to update with active cuelists, so it may get old data for a few polls. Unfortunately we're kind of limited there with the telnet interface.

Looks like my IDE auto re-formatted a lot of things too. Hope that's not a problem.