### PR TITLE
Fixes after telnet lib change

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,7 @@ instance.prototype.init_tcp = function() {
 						}
 						break;
 				}
-				console.log(line);
 			});
-			console.log(self.activeCuelists);
 			self.checkFeedbacks("cuelist_active");
 		});
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-var tcp = require('../../tcp');
-var instance_skel = require('../../instance_skel');
-var TelnetSocket = require('../../telnet');
+var tcp = require("../../tcp");
+var instance_skel = require("../../instance_skel");
+var TelnetSocket = require("../../telnet");
 
 var debug;
 var log;
@@ -12,7 +12,7 @@ function instance(system, id, config) {
 	self.request_id = 0;
 	// super-constructor
 	instance_skel.apply(this, arguments);
-	self.status(self.STATUS_WARNING, 'Initializing');
+	self.status(self.STATUS_WARNING, "Initializing");
 	self.actions(); // export actions
 
 	self.activeCuelists = [];
@@ -38,7 +38,7 @@ instance.prototype.init = function() {
 
 instance.prototype.init_tcp = function() {
 	var self = this;
-	self.buffer = '';
+	self.buffer = "";
 
 	if (self.socket !== undefined) {
 		self.socket.destroy();
@@ -48,27 +48,25 @@ instance.prototype.init_tcp = function() {
 	if (self.config.host) {
 		self.socket = new TelnetSocket(self.config.host, self.config.port);
 
-		self.socket.on('status_change', function (status, message) {
+		self.socket.on("status_change", function(status, message) {
 			self.status(status, message);
 		});
 
-		self.socket.on('connect', function () {
+		self.socket.on("connect", function() {
 			if (self.config.polling_interval > 0) {
 				if (self.pollTimer) {
 					clearInterval(self.pollTimer);
 				}
 
-				self.pollTimer = setInterval(function () {
+				self.pollTimer = setInterval(function() {
 					self.pollActiveCuelists();
-				},
-					self.config.polling_interval
-				);
+				}, self.config.polling_interval);
 			}
 		});
 
-		self.socket.on('error', function (err) {
+		self.socket.on("error", function(err) {
 			debug("Network error", err);
-			self.log('error',"Network error: " + err.message);
+			self.log("error", "Network error: " + err.message);
 		});
 
 		// if we get any data, display it to stdout
@@ -77,7 +75,7 @@ instance.prototype.init_tcp = function() {
 			self.buffer += indata;
 
 			var lines = self.buffer.split("\r\n");
-			if (lines.indexOf('.') === -1) {
+			if (lines.indexOf(".") === -1) {
 				return;
 			}
 
@@ -86,32 +84,34 @@ instance.prototype.init_tcp = function() {
 					// Ignore lines that aren't part of the active cuelist list.
 					case "200 Ok":
 					case "200 ":
-					case ".":
 					case "":
 					case "No Active Qlist in List":
 						break;
+					case ".":
+						self.buffer = "";
 					default:
 						var id = parseInt(line.substring(0, 5));
-						self.activeCuelists.push(id);
+						if (!isNaN(id)) {
+							self.activeCuelists.push(id);
+						}
 						break;
 				}
+				console.log(line);
 			});
-
+			console.log(self.activeCuelists);
 			self.checkFeedbacks("cuelist_active");
 		});
 
 		self.socket.on("do", function(type, info) {
-
 			// tell remote we WONT do anything we're asked to DO
-			if (type == 'DO') {
-				self.socket.write(new Buffer([ 255, 252, info ]));
+			if (type == "DO") {
+				self.socket.write(new Buffer([255, 252, info]));
 			}
 
 			// tell the remote DONT do whatever they WILL offer
-			if (type == 'WILL') {
-				self.socket.write(new Buffer([ 255, 254, info ]));
+			if (type == "WILL") {
+				self.socket.write(new Buffer([255, 254, info]));
 			}
-
 		});
 	}
 };
@@ -122,7 +122,7 @@ instance.prototype.pollActiveCuelists = function() {
 	self.gettingActiveQL = true;
 	self.activeCuelists = [];
 
-	self.write("QLActive\r\n");
+	self.socket.write("QLActive\r\n");
 };
 
 // Return config fields for web config
@@ -173,14 +173,14 @@ instance.prototype.destroy = function() {
 	}
 
 	if (self.socket !== undefined) {
-			self.socket.destroy();
-			delete self.socket;
+		self.socket.destroy();
+		delete self.socket;
 	}
 
 	debug("destroy", self.id);
 };
 
-instance.prototype.actions = function () {
+instance.prototype.actions = function() {
 	var self = this;
 
 	self.setActions({


### PR DESCRIPTION
A couple fixes for the module after the telnet lib was changed.

`pollActiveCuelists` now properly calls `self.socket.write()` instead of `self.write`

The buffer is now flushed when it receives a newline with only a `.` in the telnet feed. This is how the Onyx server lets you know it has finished sending a command.

If we get telnet feedback that we can't parse into a number it gets ignored instead of added to self.activeCluelists.

My IDE re-quoted and indented some of the code, hopefully that's not an issue for merging.

Fixes #1 