### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,12 +103,12 @@ instance.prototype.init_tcp = function() {
 		self.socket.on("do", function(type, info) {
 			// tell remote we WONT do anything we're asked to DO
 			if (type == "DO") {
-				self.socket.write(new Buffer([255, 252, info]));
+				self.socket.write(Buffer.from([255, 252, info]));
 			}
 
 			// tell the remote DONT do whatever they WILL offer
 			if (type == "WILL") {
-				self.socket.write(new Buffer([255, 254, info]));
+				self.socket.write(Buffer.from([255, 254, info]));
 			}
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidiancontrol-onyx",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "A Companion module to control Onyx and M-Series based lighting systems",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/